### PR TITLE
fix(storybook): Externalize react-router dependency from the library

### DIFF
--- a/packages/ui/vite.config.lib.ts
+++ b/packages/ui/vite.config.lib.ts
@@ -18,6 +18,7 @@ export const getConfig = (): UserConfig => ({
       external: [
         'react',
         'react-dom',
+        'react-router-dom',
         '@patternfly/patternfly',
         '@patternfly/react-code-editor',
         '@patternfly/react-core',
@@ -32,6 +33,7 @@ export const getConfig = (): UserConfig => ({
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          'react-router-dom': 'react-router-dom',
           '@patternfly/patternfly': '@patternfly/patternfly',
           '@patternfly/react-code-editor': '@patternfly/react-code-editor',
           '@patternfly/react-core': '@patternfly/react-core',

--- a/packages/ui/vite.config.testing-lib.ts
+++ b/packages/ui/vite.config.testing-lib.ts
@@ -11,10 +11,6 @@ testingConfig.build!.lib = {
 };
 testingConfig.build!.rollupOptions!.output = {
   ...testingConfig.build!.rollupOptions!.output,
-  globals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
-  },
   assetFileNames: 'testing-[name][extname]',
 };
 


### PR DESCRIPTION
### Context
While working with storybook, we noticed that some dependencies were embedded into the exported library.

This is counter-productive since it means that consumers of the library won't have the possibility to provide their own dependencies.

### Changes
The fix is to externalize most of the dependencies at the build stage.