### PR TITLE
fix: Canvas context menu

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.tsx
@@ -1,40 +1,31 @@
 import { Menu, MenuContainer, MenuContent, MenuItem, MenuList, MenuToggle } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
-import { FunctionComponent, ReactElement, useCallback, useContext, useRef, useState } from 'react';
-import { BaseVisualCamelEntityDefinition } from '../../../../models/camel/camel-resource';
+import { FunctionComponent, ReactElement, useCallback, useRef, useState } from 'react';
+import { useCanvasEntities } from '../../../../hooks/useCanvasEntities';
 import { EntityType } from '../../../../models/camel/entities';
-import { EntitiesContext } from '../../../../providers/entities.provider';
-import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
 import './NewEntity.scss';
-import { sourceSchemaConfig } from '../../../../testing-api';
 
 export const NewEntity: FunctionComponent = () => {
-  const { camelResource, updateEntitiesFromCamelResource } = useContext(EntitiesContext)!;
-  const visibleFlowsContext = useContext(VisibleFlowsContext)!;
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
-  const groupedEntities = useRef<BaseVisualCamelEntityDefinition>(camelResource.getCanvasEntityList());
-  const { currentSchemaType } = useContext(EntitiesContext)!;
-  const isMultipleRoutes = sourceSchemaConfig.config[currentSchemaType].multipleRoute;
+  const { commonEntities, groupedEntities, createEntity } = useCanvasEntities();
 
   const onSelect = useCallback(
-    (_event: unknown, entityType: string | number | undefined) => {
+    (event: unknown, entityType: string | number | undefined) => {
+      // Prevent event bubbling to avoid context menu auto-close
+      if (event && typeof event === 'object' && 'stopPropagation' in event) {
+        (event as Event).stopPropagation();
+      }
+
       if (!entityType) {
         return;
       }
 
-      /**
-       * If it's the same DSL as we have in the existing Flows list,
-       * we don't need to do anything special, just add a new flow if
-       * supported
-       */
-      const newId = camelResource.addNewEntity(entityType as EntityType);
-      visibleFlowsContext.visualFlowsApi.toggleFlowVisible(newId);
-      updateEntitiesFromCamelResource();
+      createEntity(entityType as EntityType);
       setIsOpen(false);
     },
-    [camelResource, updateEntitiesFromCamelResource, visibleFlowsContext.visualFlowsApi],
+    [createEntity],
   );
 
   const getMenuItem = useCallback(
@@ -63,9 +54,7 @@ export const NewEntity: FunctionComponent = () => {
     },
     [],
   );
-  if (!isMultipleRoutes) {
-    return null;
-  }
+
   return (
     <MenuContainer
       isOpen={isOpen}
@@ -74,9 +63,9 @@ export const NewEntity: FunctionComponent = () => {
         <Menu ref={menuRef} containsFlyout onSelect={onSelect}>
           <MenuContent>
             <MenuList>
-              {groupedEntities.current.common.map((entityDef) => getMenuItem(entityDef))}
+              {commonEntities.map((entityDef) => getMenuItem(entityDef))}
 
-              {Object.entries(groupedEntities.current.groups).map(([group, entities]) => {
+              {Object.entries(groupedEntities).map(([group, entities]) => {
                 const flyoutMenu = (
                   <Menu className="entities-menu__submenu" onSelect={onSelect}>
                     <MenuContent>

--- a/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/CustomGraph.tsx
@@ -1,26 +1,55 @@
-import type { ElementModel, GraphElement } from '@patternfly/react-topology';
-import { GraphComponent, withContextMenu, withPanZoom } from '@patternfly/react-topology';
-import { ReactElement } from 'react';
-import { NewEntity } from '../../ContextToolbar/NewEntity/NewEntity';
+import { Divider } from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import {
+  ContextSubMenuItem,
+  ElementContext,
+  GraphComponent,
+  withContextMenu,
+  withPanZoom,
+} from '@patternfly/react-topology';
+import { ReactElement, useContext } from 'react';
 import { ShowOrHideAllFlows } from './ShowOrHideAllFlows';
+import { withEntityContextMenu, WithEntityContextMenuProps } from './withEntityContextMenu';
 
-export const GraphContextMenuFn = (element: GraphElement<ElementModel, unknown>): ReactElement[] => {
-  const items: ReactElement[] = [];
-
-  items.push(
+export const GraphContextMenuFn = (entityContextMenuFn: () => ReactElement[]): ReactElement[] => {
+  const items: ReactElement[] = [
     <ShowOrHideAllFlows key="showAll" data-testid="context-menu-item-show-all" mode="showAll">
       Show all
     </ShowOrHideAllFlows>,
-  );
-
-  items.push(
     <ShowOrHideAllFlows key="hideAll" data-testid="context-menu-item-hide-all" mode="hideAll">
       Hide all
     </ShowOrHideAllFlows>,
-  );
+  ];
 
-  items.push(<NewEntity />);
+  const entities = entityContextMenuFn();
+
+  if (entities.length > 0) {
+    items.push(<Divider key="new-entity-divider" />);
+    items.push(
+      <ContextSubMenuItem
+        key="new-entity"
+        data-testid="context-menu-item-new-entity"
+        label={
+          <>
+            <PlusIcon />
+            <span className="pf-v6-u-m-sm">New</span>
+          </>
+        }
+      >
+        {entities}
+      </ContextSubMenuItem>,
+    );
+  }
+
   return items;
 };
 
-export const CustomGraphWithSelection = withPanZoom()(withContextMenu(GraphContextMenuFn)(GraphComponent));
+const BaseCustomGraph = ({ entityContextMenuFn, ...rest }: WithEntityContextMenuProps) => {
+  const contextMenuFn = () => GraphContextMenuFn(entityContextMenuFn);
+  const element = useContext(ElementContext);
+  const EnhancedGraphComponent = withPanZoom()(withContextMenu(contextMenuFn)(GraphComponent));
+
+  return <EnhancedGraphComponent {...rest} element={element} />;
+};
+
+export const CustomGraphWithSelection = withEntityContextMenu(BaseCustomGraph);

--- a/packages/ui/src/components/Visualization/Custom/Graph/generateEntityContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/generateEntityContextMenu.tsx
@@ -1,0 +1,51 @@
+import { ContextMenuItem, ContextSubMenuItem } from '@patternfly/react-topology';
+import React from 'react';
+import { CanvasEntities } from '../../../../hooks/useCanvasEntities';
+
+export const generateEntityContextMenu = (entityData: CanvasEntities) => {
+  const { commonEntities, groupedEntities, createEntity } = entityData;
+  const items: React.ReactElement[] = [];
+
+  commonEntities.forEach((entity) => {
+    items.push(
+      <ContextMenuItem
+        key={`new-entity-${entity.name}`}
+        data-testid={`new-entity-${entity.name}`}
+        onClick={() => createEntity(entity.name)}
+        description={
+          <span className="pf-v6-u-text-break-word" style={{ wordBreak: 'keep-all' }}>
+            {entity.description}
+          </span>
+        }
+      >
+        {entity.title}
+      </ContextMenuItem>,
+    );
+  });
+
+  // Add grouped entities as submenus
+  Object.entries(groupedEntities).forEach(([groupName, entities]) => {
+    const subItems = entities.map((entity) => (
+      <ContextMenuItem
+        key={`new-entity-${entity.name}`}
+        data-testid={`new-entity-${entity.name}`}
+        onClick={() => createEntity(entity.name)}
+        description={
+          <span className="pf-v6-u-text-break-word" style={{ wordBreak: 'keep-all' }}>
+            {entity.description}
+          </span>
+        }
+      >
+        {entity.title}
+      </ContextMenuItem>
+    ));
+
+    items.push(
+      <ContextSubMenuItem key={groupName} label={groupName}>
+        {subItems}
+      </ContextSubMenuItem>,
+    );
+  });
+
+  return items;
+};

--- a/packages/ui/src/components/Visualization/Custom/Graph/withEntityContextMenu.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Graph/withEntityContextMenu.tsx
@@ -1,0 +1,20 @@
+import { WithContextMenuProps } from '@patternfly/react-topology';
+import React, { ComponentType, useMemo } from 'react';
+import { useCanvasEntities } from '../../../../hooks/useCanvasEntities';
+import { generateEntityContextMenu } from './generateEntityContextMenu';
+
+export interface WithEntityContextMenuProps {
+  entityContextMenuFn: () => React.ReactElement[];
+}
+
+export const withEntityContextMenu = <P extends WithContextMenuProps>(
+  WrappedComponent: ComponentType<P & WithEntityContextMenuProps>,
+) => {
+  return (props: P) => {
+    const entityData = useCanvasEntities();
+
+    const entityContextMenuFn = useMemo(() => () => generateEntityContextMenu(entityData), [entityData]);
+
+    return <WrappedComponent {...props} entityContextMenuFn={entityContextMenuFn} />;
+  };
+};

--- a/packages/ui/src/hooks/useCanvasEntities.ts
+++ b/packages/ui/src/hooks/useCanvasEntities.ts
@@ -1,0 +1,37 @@
+import { useCallback, useContext, useMemo, useRef } from 'react';
+import { BaseVisualCamelEntityDefinition, BaseVisualCamelEntityDefinitionItem } from '../models/camel/camel-resource';
+import { EntityType } from '../models/camel/entities';
+import { EntitiesContext } from '../providers/entities.provider';
+import { VisibleFlowsContext } from '../providers/visible-flows.provider';
+
+export interface CanvasEntities {
+  commonEntities: BaseVisualCamelEntityDefinitionItem[];
+  groupedEntities: Record<string, BaseVisualCamelEntityDefinitionItem[]>;
+  createEntity: (entityType: EntityType) => void;
+}
+
+export const useCanvasEntities = (): CanvasEntities => {
+  const { camelResource, updateEntitiesFromCamelResource } = useContext(EntitiesContext)!;
+  const visibleFlowsContext = useContext(VisibleFlowsContext)!;
+  const groupedEntities = useRef<BaseVisualCamelEntityDefinition>(camelResource.getCanvasEntityList());
+
+  const createEntity = useCallback(
+    (entityType: EntityType) => {
+      const newId = camelResource.addNewEntity(entityType);
+      visibleFlowsContext.visualFlowsApi.toggleFlowVisible(newId);
+      updateEntitiesFromCamelResource();
+    },
+    [camelResource, updateEntitiesFromCamelResource, visibleFlowsContext.visualFlowsApi],
+  );
+
+  const result = useMemo(
+    () => ({
+      commonEntities: groupedEntities.current.common,
+      groupedEntities: groupedEntities.current.groups,
+      createEntity,
+    }),
+    [createEntity],
+  );
+
+  return result;
+};


### PR DESCRIPTION
### Context
There is a problem when using the `MenuItem` components in the `ContextMenu` component, making them unusable.

This PR moved the entity context menu generation into a dedicated hook (`useCanvasEntities`) and helper (`generateEntityContextMenu`), so we could reuse it in both `NewEntity` and `CustomGraph` components.

There were limitations when using hooks since they can only be executed in React components, so I updated the code to introduce HOC (higher-order component) to accommodate this.

### Pending topics
* Add unit tests for the existing and new files
* Make the menu wider, so we can better read the descriptions

<img width="386" height="615" alt="image" src="https://github.com/user-attachments/assets/afc0d29b-e031-4ee1-bf83-ae8b66040059" />
