### PR TITLE
feat(Datamapper): Show Field types icons

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,7 @@
     "lint:style:fix": "yarn lint:style --fix"
   },
   "dependencies": {
+    "@carbon/icons-react": "^11.67.0",
     "@dnd-kit/core": "^6.1.0",
     "@kaoto/forms": "^1.4.1",
     "@kie-tools-core/editor": "^10.0.0",

--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -56,7 +56,7 @@ describe('DebugLayout', () => {
         </DataMapperCanvasProvider>
       </DataMapperProvider>,
     );
-    await screen.findAllByText('ShipOrder : Container');
+    await screen.findAllByText('ShipOrder');
     const targetNodes = screen.getAllByTestId(/node-target-.*/);
     expect(targetNodes.length).toEqual(21);
     expect(mappingLinks.length).toEqual(11);

--- a/packages/ui/src/components/Document/Document.scss
+++ b/packages/ui/src/components/Document/Document.scss
@@ -76,10 +76,6 @@ img {
   }
 }
 
-.truncate {
-  --pf-v6-c-truncate--MinWidth: 0;
-}
-
 /* stylelint-disable-next-line selector-class-pattern */
 .pf-v6-c-action-list__group {
   padding-left: 0.5rem;

--- a/packages/ui/src/components/Document/FieldIcon.tsx
+++ b/packages/ui/src/components/Document/FieldIcon.tsx
@@ -1,0 +1,82 @@
+import {
+  Array,
+  Boolean,
+  CalendarHeatMap,
+  CharacterDecimal,
+  Document,
+  EventSchedule,
+  Help,
+  Hourglass,
+  Http,
+  Object,
+  StringInteger,
+  StringText,
+  Time,
+} from '@carbon/icons-react';
+import { Icon } from '@patternfly/react-core';
+import { FunctionComponent, useMemo } from 'react';
+import { Types } from '../../models/datamapper';
+
+interface FieldIconProps {
+  type?: Types;
+  className?: string;
+}
+
+export const FieldIcon: FunctionComponent<FieldIconProps> = ({ type, className }) => {
+  const iconNode = useMemo(() => {
+    switch (type) {
+      case Types.String:
+        return <StringText />;
+
+      case Types.Integer:
+      case Types.PositiveInteger:
+        return <StringInteger />;
+
+      case Types.Float:
+      case Types.Double:
+      case Types.Decimal:
+      case Types.Numeric:
+        return <CharacterDecimal />;
+
+      case Types.Boolean:
+        return <Boolean />;
+      case Types.Date:
+        return <CalendarHeatMap />;
+      case Types.Time:
+        return <Time />;
+
+      case Types.DateTime:
+        return <EventSchedule />;
+      case Types.Duration:
+      case Types.DayTimeDuration:
+        return <Hourglass />;
+
+      case Types.Container:
+        return <Object />;
+      case Types.Array:
+        return <Array />;
+      case Types.DocumentNode:
+        return <Document />;
+      case Types.AnyURI:
+        return <Http />;
+
+      case Types.AnyAtomicType:
+      case Types.AnyType:
+        return <Help />;
+
+      case Types.QName:
+      case Types.NCName:
+      case Types.Item:
+      case Types.Element:
+      case Types.Node:
+      default:
+        return null;
+    }
+  }, [type]);
+
+  return (
+    <Icon className={className} title={type}>
+      {iconNode}
+    </Icon>
+  );
+};

--- a/packages/ui/src/components/Document/NodeTitle.scss
+++ b/packages/ui/src/components/Document/NodeTitle.scss
@@ -1,0 +1,9 @@
+.node-title {
+  &__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+    display: inline-block;
+  }
+}

--- a/packages/ui/src/components/Document/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { NodeTitle } from './NodeTitle';
+import { DocumentNodeData, FieldNodeData } from '../../models/datamapper/visualization';
+import { DocumentType, PrimitiveDocument, BODY_DOCUMENT_ID } from '../../models/datamapper/document';
+import { TestUtil } from '../../stubs/datamapper/data-mapper';
+
+describe('NodeTitle', () => {
+  const createMockField = () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    return shipOrderDoc.fields[0]; // Use a real field from test data
+  };
+
+  it('should render document title with Title component when isDocument is true', () => {
+    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const documentNodeData = new DocumentNodeData(primitiveDoc);
+
+    render(<NodeTitle nodeData={documentNodeData} isDocument={true} />);
+
+    const titleElement = screen.getByRole('heading', { level: 5 });
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent('Body');
+  });
+
+  it('should render field title with Truncate when isDocument is false', () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const mockField = createMockField();
+    const fieldNodeData = new FieldNodeData(documentNodeData, mockField);
+
+    render(<NodeTitle nodeData={fieldNodeData} isDocument={false} />);
+
+    expect(screen.getByText(mockField.displayName)).toBeInTheDocument();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('should render with truncate class by default for document node', () => {
+    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const documentNodeData = new DocumentNodeData(primitiveDoc);
+
+    render(<NodeTitle nodeData={documentNodeData} isDocument={false} />);
+
+    const element = screen.getByText('Body');
+    expect(element).toHaveClass('node-title__text');
+  });
+
+  it('should render content correctly with custom className', () => {
+    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const documentNodeData = new DocumentNodeData(primitiveDoc);
+    const customClass = 'custom-test-class';
+
+    render(<NodeTitle nodeData={documentNodeData} isDocument={true} className={customClass} />);
+
+    const titleElement = screen.getByRole('heading', { level: 5 });
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent('Body');
+  });
+
+  it('should handle PrimitiveDocument node data', () => {
+    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, 'primitive-doc');
+    const primitiveNodeData = new DocumentNodeData(primitiveDoc);
+
+    render(<NodeTitle nodeData={primitiveNodeData} isDocument={true} />);
+
+    const titleElement = screen.getByRole('heading', { level: 5 });
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent('primitive-doc');
+  });
+
+  it('should handle long titles with truncation', () => {
+    const longTitle = 'This is a very long document title that should be truncated properly when rendered';
+    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, longTitle);
+    const documentNodeData = new DocumentNodeData(primitiveDoc);
+
+    render(<NodeTitle nodeData={documentNodeData} isDocument={true} />);
+
+    const titleElement = screen.getByRole('heading', { level: 5 });
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent(longTitle);
+  });
+
+  it('should render with truncate class by default', () => {
+    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const documentNodeData = new DocumentNodeData(primitiveDoc);
+
+    render(<NodeTitle nodeData={documentNodeData} isDocument={false} />);
+
+    const element = screen.getByText('Body');
+    expect(element).toHaveClass('node-title__text');
+  });
+
+  it('should handle undefined className gracefully', () => {
+    const primitiveDoc = new PrimitiveDocument(DocumentType.SOURCE_BODY, BODY_DOCUMENT_ID);
+    const documentNodeData = new DocumentNodeData(primitiveDoc);
+
+    render(<NodeTitle nodeData={documentNodeData} isDocument={false} className={undefined} />);
+
+    const element = screen.getByText('Body');
+    expect(element).toHaveClass('node-title__text');
+  });
+});

--- a/packages/ui/src/components/Document/NodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle.tsx
@@ -1,8 +1,8 @@
-import { Label, Title, Truncate } from '@patternfly/react-core';
+import { Label, Title } from '@patternfly/react-core';
 import clsx from 'clsx';
 import { FunctionComponent } from 'react';
 import { FieldItemNodeData, MappingNodeData, NodeData } from '../../models/datamapper/visualization';
-import './Document.scss';
+import './NodeTitle.scss';
 
 interface INodeTitle {
   className?: string;
@@ -11,23 +11,20 @@ interface INodeTitle {
 }
 
 export const NodeTitle: FunctionComponent<INodeTitle> = ({ className, nodeData, isDocument }) => {
+  const title = nodeData.title;
+  const content = (
+    <span title={title} className={clsx('node-title__text', className)}>
+      {title}
+    </span>
+  );
+
   if (nodeData instanceof MappingNodeData && !(nodeData instanceof FieldItemNodeData)) {
-    return (
-      <Label>
-        <Truncate content={nodeData.title ?? ''} className={clsx('truncate', className)} />
-      </Label>
-    );
+    return <Label>{content}</Label>;
   }
 
   if (isDocument) {
-    return (
-      <Title headingLevel="h5">
-        <Truncate content={nodeData.title ?? ''} className={clsx('truncate', className)} />
-      </Title>
-    );
+    return <Title headingLevel="h5">{content}</Title>;
   }
 
-  return (
-    <Truncate content={`${nodeData.title ?? ''} : ${nodeData.type ?? ''}`} className={clsx('truncate', className)} />
-  );
+  return content;
 };

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -214,7 +214,7 @@ describe('Parameters', () => {
       fireEvent.click(commitButton);
     });
 
-    const shipTo = await screen.findByText('map [@key = ShipTo] : Container');
+    const shipTo = await screen.findByText('map [@key = ShipTo]');
     expect(shipTo).toBeTruthy();
   });
 

--- a/packages/ui/src/components/Document/SourceDocument.test.tsx
+++ b/packages/ui/src/components/Document/SourceDocument.test.tsx
@@ -27,8 +27,8 @@ describe('SourceDocument', () => {
         </DataMapperCanvasProvider>
       </DataMapperProvider>,
     );
-    expect(await screen.findByText('OrderPerson : string')).toBeTruthy();
-    expect(await screen.findByText('Country : string')).toBeInTheDocument();
+    expect(await screen.findByText('OrderPerson')).toBeTruthy();
+    expect(await screen.findByText('Country')).toBeInTheDocument();
   });
 
   it('should render camel-spring.xsd doc till 2nd level', async () => {
@@ -41,9 +41,9 @@ describe('SourceDocument', () => {
       </DataMapperProvider>,
     );
     await waitFor(async () => {
-      const aggregates = await screen.findAllByText('aggregate : Container');
+      const aggregates = await screen.findAllByText('aggregate');
       expect(aggregates.length).toEqual(2);
     });
-    expect(await screen.findByText('correlationExpression : Container')).toBeTruthy();
+    expect(await screen.findByText('correlationExpression')).toBeTruthy();
   }, 15_000);
 });

--- a/packages/ui/src/components/Document/SourceDocument.tsx
+++ b/packages/ui/src/components/Document/SourceDocument.tsx
@@ -1,17 +1,19 @@
+import { At, ChevronDown, ChevronRight, Draggable } from '@carbon/icons-react';
 import { Icon } from '@patternfly/react-core';
-import { AngleDownIcon, AtIcon, GripVerticalIcon, LayerGroupIcon } from '@patternfly/react-icons';
+import { LayerGroupIcon } from '@patternfly/react-icons';
 import clsx from 'clsx';
 import { FunctionComponent, MouseEvent, useCallback, useRef, useState } from 'react';
 import { useCanvas } from '../../hooks/useCanvas';
 import { useDataMapper } from '../../hooks/useDataMapper';
+import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { IDocument } from '../../models/datamapper/document';
 import { DocumentNodeData, NodeData, NodeReference } from '../../models/datamapper/visualization';
 import { VisualizationService } from '../../services/visualization.service';
 import { DocumentActions } from './actions/DocumentActions';
 import './Document.scss';
+import { FieldIcon } from './FieldIcon';
 import { NodeContainer } from './NodeContainer';
 import { NodeTitle } from './NodeTitle';
-import { useMappingLinks } from '../../hooks/useMappingLinks';
 
 type DocumentProps = {
   document: IDocument;
@@ -108,16 +110,16 @@ export const SourceDocumentNode: FunctionComponent<DocumentNodeProps> = ({
             <section className="node__row" data-draggable={isDraggable}>
               {hasChildren && (
                 <Icon className="node__spacer" onClick={handleClickToggle}>
-                  <AngleDownIcon
-                    data-testid={`expand-source-icon-${nodeData.title}`}
-                    className={clsx('toggle-icon', { 'toggle-icon--collapsed': collapsed })}
-                  />
+                  {!collapsed && <ChevronDown />}
+                  {collapsed && <ChevronRight />}
                 </Icon>
               )}
 
               <Icon className="node__spacer" data-drag-handler>
-                <GripVerticalIcon />
+                <Draggable />
               </Icon>
+
+              <FieldIcon className="node__spacer" type={nodeData.type} />
 
               {isCollectionField && (
                 <Icon className="node__spacer">
@@ -127,7 +129,7 @@ export const SourceDocumentNode: FunctionComponent<DocumentNodeProps> = ({
 
               {isAttributeField && (
                 <Icon className="node__spacer">
-                  <AtIcon />
+                  <At />
                 </Icon>
               )}
 

--- a/packages/ui/src/components/Document/TargetDocument.tsx
+++ b/packages/ui/src/components/Document/TargetDocument.tsx
@@ -1,16 +1,11 @@
+import { At, ChevronDown, ChevronRight, Draggable } from '@carbon/icons-react';
 import { ActionList, ActionListGroup, ActionListItem, Button, Icon } from '@patternfly/react-core';
-import {
-  AngleDownIcon,
-  AtIcon,
-  GripVerticalIcon,
-  LayerGroupIcon,
-  PlusCircleIcon,
-  PlusIcon,
-} from '@patternfly/react-icons';
+import { LayerGroupIcon, PlusCircleIcon, PlusIcon } from '@patternfly/react-icons';
 import clsx from 'clsx';
 import { FunctionComponent, MouseEvent, useCallback, useRef, useState } from 'react';
 import { useCanvas } from '../../hooks/useCanvas';
 import { useDataMapper } from '../../hooks/useDataMapper';
+import { useMappingLinks } from '../../hooks/useMappingLinks';
 import { IDocument } from '../../models/datamapper/document';
 import {
   AddMappingNodeData,
@@ -19,13 +14,13 @@ import {
   TargetNodeData,
 } from '../../models/datamapper/visualization';
 import { VisualizationService } from '../../services/visualization.service';
+import { ConditionMenuAction } from './actions/ConditionMenuAction';
 import { DocumentActions } from './actions/DocumentActions';
 import { TargetNodeActions } from './actions/TargetNodeActions';
 import './Document.scss';
+import { FieldIcon } from './FieldIcon';
 import { NodeContainer } from './NodeContainer';
 import { NodeTitle } from './NodeTitle';
-import { ConditionMenuAction } from './actions/ConditionMenuAction';
-import { useMappingLinks } from '../../hooks/useMappingLinks';
 
 type DocumentProps = {
   document: IDocument;
@@ -126,16 +121,16 @@ const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({
             <section className="node__row" data-draggable={isDraggable}>
               {hasChildren && (
                 <Icon className="node__spacer" onClick={handleClickToggle}>
-                  <AngleDownIcon
-                    data-testid={`expand-target-icon-${nodeData.title}`}
-                    className={clsx('toggle-icon', { 'toggle-icon--collapsed': collapsed })}
-                  />
+                  {!collapsed && <ChevronDown />}
+                  {collapsed && <ChevronRight />}
                 </Icon>
               )}
 
               <Icon className="node__spacer" data-drag-handler>
-                <GripVerticalIcon />
+                <Draggable />
               </Icon>
+
+              <FieldIcon className="node__spacer" type={nodeData.type} />
 
               {isCollectionField && (
                 <Icon className="node__spacer">
@@ -145,7 +140,7 @@ const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = ({
 
               {isAttributeField && (
                 <Icon className="node__spacer">
-                  <AtIcon />
+                  <At />
                 </Icon>
               )}
 

--- a/packages/ui/src/components/View/SourceTargetView.test.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.test.tsx
@@ -46,7 +46,7 @@ describe('SourceTargetView', () => {
         fireEvent.click(commitButton);
       });
 
-      const shipTo = await screen.findByText('ShipTo : Container');
+      const shipTo = await screen.findByText('ShipTo');
       expect(shipTo).toBeTruthy();
       const detachButton = screen.getByTestId('detach-schema-sourceBody-Body-button');
       act(() => {
@@ -124,7 +124,7 @@ describe('SourceTargetView', () => {
         fireEvent.click(commitButton);
       });
 
-      const shipTo = await screen.findByText('ShipTo : Container');
+      const shipTo = await screen.findByText('ShipTo');
       expect(shipTo).toBeTruthy();
       const detachButton = screen.getByTestId('detach-schema-targetBody-Body-button');
       act(() => {
@@ -180,7 +180,7 @@ describe('SourceTargetView', () => {
         fireEvent.click(commitButton);
       });
 
-      const shipTo = await screen.findByText('map [@key = ShipTo] : Container');
+      const shipTo = await screen.findByText('map [@key = ShipTo]');
       expect(shipTo).toBeTruthy();
       const detachButton = screen.getByTestId('detach-schema-targetBody-Body-button');
       act(() => {
@@ -191,7 +191,7 @@ describe('SourceTargetView', () => {
         fireEvent.click(detachConfirmButton);
       });
       await screen.findByTestId('attach-schema-sourceBody-Body-button');
-      expect(screen.queryByText('map [@key = ShipTo] : Container')).toBeFalsy();
+      expect(screen.queryByText('map [@key = ShipTo]')).toBeFalsy();
     });
 
     it('should attach Camel YAML JSON schema', async () => {

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -1,13 +1,14 @@
+import { AlertProps } from '@patternfly/react-core';
+import { RefObject } from 'react';
 import { DocumentType, IDocument, IField, PrimitiveDocument } from './document';
 import { ExpressionItem, FieldItem, IFunctionDefinition, MappingItem, MappingParentType, MappingTree } from './mapping';
 import { NodePath } from './nodepath';
-import { RefObject } from 'react';
-import { AlertProps } from '@patternfly/react-core';
+import { Types } from './types';
 
 export interface NodeData {
   title: string;
   document?: IDocument;
-  type?: string;
+  type?: Types;
   id: string;
   path: NodePath;
   isSource: boolean;
@@ -65,7 +66,7 @@ export class FieldNodeData implements NodeData {
 
   title: string;
   id: string;
-  type: string;
+  type: Types;
   path: NodePath;
   isSource: boolean;
   isPrimitive: boolean;

--- a/packages/ui/src/providers/datamapper-canvas.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper-canvas.provider.test.tsx
@@ -69,7 +69,7 @@ describe('CanvasProvider', () => {
         </DataMapperCanvasProvider>
       </DataMapperProvider>,
     );
-    await screen.findAllByText('ShipOrder : Container');
+    await screen.findAllByText('ShipOrder');
     expect(afterNodePaths.length).toEqual(17);
     expect(beforeNodePaths.length).toBeGreaterThan(afterNodePaths.length);
   });
@@ -113,7 +113,7 @@ describe('CanvasProvider', () => {
         </DataMapperCanvasProvider>
       </DataMapperProvider>,
     );
-    await screen.findAllByText('ShipOrder : Container');
+    await screen.findAllByText('ShipOrder');
     expect(afterNodePaths.length).toBeGreaterThan(10);
     expect(beforeNodePaths.length).toBeGreaterThan(afterNodePaths.length);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2008,6 +2008,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/icon-helpers@npm:^10.66.0":
+  version: 10.66.0
+  resolution: "@carbon/icon-helpers@npm:10.66.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.5.0"
+  checksum: 10/63d1a63e4e3eeb53955bcd9e9f2f42f47b1c7cceb341e8398d249424826c79359070d09b8a76f773aabe77299f02253ae6d9e8bd5e51c987848cd99f6377178f
+  languageName: node
+  linkType: hard
+
+"@carbon/icons-react@npm:^11.67.0":
+  version: 11.67.0
+  resolution: "@carbon/icons-react@npm:11.67.0"
+  dependencies:
+    "@carbon/icon-helpers": "npm:^10.66.0"
+    "@ibm/telemetry-js": "npm:^1.5.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    react: ">=16"
+  checksum: 10/f4dd61a3e5a73dd1725c3271fad398d7360d7ebf7c0ca2874c83cf043e5dcbe3295b57a51524db0e62e502c5bd226f5973bbbf5427707b9d19698e39d98dbbbc
+  languageName: node
+  linkType: hard
+
 "@chevrotain/cst-dts-gen@npm:10.5.0":
   version: 10.5.0
   resolution: "@chevrotain/cst-dts-gen@npm:10.5.0"
@@ -2466,6 +2488,15 @@ __metadata:
   version: 5.0.0
   resolution: "@hutson/parse-repository-url@npm:5.0.0"
   checksum: 10/040bc80dd1be5b12718af8a1d2fc58bbf793d41040ad4cedfe864079fddb542f106aee998beb7e42b7ebf882237e45b559bdf1ed3f6a607a403e51d849f37118
+  languageName: node
+  linkType: hard
+
+"@ibm/telemetry-js@npm:^1.5.0":
+  version: 1.10.2
+  resolution: "@ibm/telemetry-js@npm:1.10.2"
+  bin:
+    ibmtelemetry: dist/collect.js
+  checksum: 10/bc1802cf691b0bb9df8cc19c8f4ab03b8022b5a53df778a9e99c817f708c51a02f440ea395ceb3656f057c8aa6356d5271f54eb3af3bcbb5c0b536fea9af2e36
   languageName: node
   linkType: hard
 
@@ -3076,6 +3107,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.21.5"
     "@babel/preset-react": "npm:^7.18.6"
     "@babel/preset-typescript": "npm:^7.21.5"
+    "@carbon/icons-react": "npm:^11.67.0"
     "@dnd-kit/core": "npm:^6.1.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.2.2"


### PR DESCRIPTION
### Context
This PR introduces icons for the field types instead of their names. It adds the `@carbon/icons-react` library to get access to type icons.

### Screenshot
<img width="2155" height="1102" alt="Screenshot From 2025-09-19 12-06-32" src="https://github.com/user-attachments/assets/317949d4-4fd4-4057-aebd-dc921315f352" />

fix: https://github.com/KaotoIO/kaoto/issues/1848